### PR TITLE
Fixing camera position vectors.

### DIFF
--- a/src/Camera.h
+++ b/src/Camera.h
@@ -32,15 +32,15 @@ public:
     glm::mat4 viewMatrix;
     /// The projection matrix of the camera
     glm::mat4 projectionMatrix();
-    /// Update the camera view matrix by looking at the target from the current position with the up vector (0,0,1)
+    /// Update the camera view matrix by looking at the target from the current position with the up vector (0,1,0)
     void lookAt(glm::vec3 target);
     /// Compute the aspect ratio of the window
     float aspectRatio();
 
 private:
     const glm::vec3 worldRight = glm::vec3(1, 0, 0);
-    const glm::vec3 worldForward = glm::vec3(0, 1, 0);
-    const glm::vec3 worldUp = glm::vec3(0, 0, 1);
+    const glm::vec3 worldForward = glm::vec3(0, 0, 1);
+    const glm::vec3 worldUp = glm::vec3(0, 1, 0);
 
     glm::vec2 cameraAngles = glm::vec2(-0.1, 0.2);
     float zoom = -2;


### PR DESCRIPTION
I think there is an inconsistency between up and forward vector definitions in Cameras.h, Camera.cpp and guide.md files. 
https://github.com/tum-pbs/game-physics-template/blob/3324eb09c77557f774947107797dbe039e1bfcac/src/Camera.h#L42-L43
https://github.com/tum-pbs/game-physics-template/blob/3324eb09c77557f774947107797dbe039e1bfcac/src/Camera.cpp#L50-L58
https://github.com/tum-pbs/game-physics-template/blob/3324eb09c77557f774947107797dbe039e1bfcac/guide.md#L409
