### PR TITLE
Fix colormap sanitization

### DIFF
--- a/src/Colormap.cpp
+++ b/src/Colormap.cpp
@@ -53,7 +53,11 @@ void Colormap::init()
     std::string line;
     int offset = 0;
     while (std::getline(file, line))
-    {
+    {        
+        // Sanitize inputs in case the file contains windows line endings, i.e. \r\n instead of \n
+        line.erase(std::remove(line.begin(), line.end(), '\r' ), line.end());
+        line.erase(std::remove(line.begin(), line.end(), '\n' ), line.end());
+
         names.push_back(line);
         indices[line] = offset;
         offset++;


### PR DESCRIPTION
Fixed an issue in the colormaps.cpp file where it failed on Linux (and potentially MacOS) from an unsanitized input (the colormaps txt file has hardcoded \r\n endings from windows). This meant that you could not pick a colormap on those operating systems. This PR should fix this issue.