### PR TITLE
Fix the X11 error when trying to run the template on Linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,11 @@ add_subdirectory(thirdparty/webgpu)
 add_subdirectory(thirdparty/glfw3webgpu)
 add_subdirectory(thirdparty/imgui)
 
+option(USE_HIGH_PERFORMANCE_GPU "Use high performance gpu by default, mostly the dircrete gpu" ON)
+if (USE_HIGH_PERFORMANCE_GPU)
+    add_compile_definitions(WGPU_GPU_HIGH_PERFORMANCE="ON")
+endif()
+
 add_executable(Template
 	src/implementations.cpp
 	src/main.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ add_subdirectory(thirdparty/webgpu)
 add_subdirectory(thirdparty/glfw3webgpu)
 add_subdirectory(thirdparty/imgui)
 
-option(USE_HIGH_PERFORMANCE_GPU "Use high performance gpu by default, mostly the dircrete gpu" ON)
+option(USE_HIGH_PERFORMANCE_GPU "Use high performance GPU, most likely a discrete GPU, should be left ON except for trouble shooting purposes." ON)
 if (USE_HIGH_PERFORMANCE_GPU)
     add_compile_definitions(WGPU_GPU_HIGH_PERFORMANCE="ON")
 endif()

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@
 
 Note that currently _WSL2 on Windows is not supported_ as there are issues with using webGPU on it, however, both Visual Studio 17 (2022) directly on Windows and MinGW are supported as alternatives. If you are facing issues on Windows in general, try cloning the repository again into a path _without any spaces_ and retry the build process. We will be adding a compatibility and common issues list soon.
 
+Tip for two GPUs but one is not in use, i.e. a desktop with an integrated GPU and a discrete GPU, and the monitor is directly plugged onto the discrete one): enable the `USE_HIGH_PERFORMANCE_GPU` option in cmake, so that webGPU automatically select the discrete one instead of the integrated one.
+
 ## Building and Running the Project
 1. Everytime you add new files, and once in the beginning, run
 ```

--- a/README.md
+++ b/README.md
@@ -20,8 +20,6 @@
 
 Note that currently _WSL2 on Windows is not supported_ as there are issues with using webGPU on it, however, both Visual Studio 17 (2022) directly on Windows and MinGW are supported as alternatives. If you are facing issues on Windows in general, try cloning the repository again into a path _without any spaces_ and retry the build process. We will be adding a compatibility and common issues list soon.
 
-Tip for two GPUs but one is not in use, i.e. a desktop with an integrated GPU and a discrete GPU, and the monitor is directly plugged onto the discrete one): enable the `USE_HIGH_PERFORMANCE_GPU` option in cmake, so that webGPU automatically select the discrete one instead of the integrated one.
-
 ## Building and Running the Project
 1. Everytime you add new files, and once in the beginning, run
 ```

--- a/src/Renderer.cpp
+++ b/src/Renderer.cpp
@@ -225,6 +225,9 @@ void Renderer::initWindowAndDevice()
 
 	RequestAdapterOptions adapterOpts{};
 	adapterOpts.compatibleSurface = surface;
+#ifdef WGPU_GPU_HIGH_PERFORMANCE
+    adapterOpts.powerPreference = WGPUPowerPreference_HighPerformance;
+#endif
 	Adapter adapter = instance.requestAdapter(adapterOpts);
 
 	SupportedLimits supportedLimits;


### PR DESCRIPTION
Resolves #8 

In order to keep the original behavior as much as possible, I introduce a CMake option that enables selection of the high-performance GPU. This will enable the marco in `Render` to set up the option correctly. I’ve also added a brief tip in the README for guidance. Feel free to make any adjustments as needed!