### PR TITLE
Change GLFWwindow forward declaration

### DIFF
--- a/src/Renderer.h
+++ b/src/Renderer.h
@@ -9,9 +9,7 @@
 #include "pipelines/ImagePipeline.h"
 #include "Camera.h"
 #include "Colormap.h"
-
-// Forward declare
-struct GLFWwindow;
+#include <GLFW/glfw3.h>
 
 /// @brief Renderer
 ///


### PR DESCRIPTION
Changed how GLFW is included in the Renderer.h file. This is  a fix to an unexpected issue when using a GLFW based input and not manually including the GLFW headers. Removing the forward declare should not be a regression on any system.

To be merged after the term as it might be breaking for some people in rare circumstances.