### PR TITLE
Fix collision detection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,7 @@ option(USE_HIGH_PERFORMANCE_GPU "Use high performance GPU, most likely a discret
 if (USE_HIGH_PERFORMANCE_GPU)
     add_compile_definitions(WGPU_GPU_HIGH_PERFORMANCE="ON")
 endif()
+configure_file(resources/config.h.in config/config.h) 
 
 add_executable(Template
 	src/implementations.cpp
@@ -37,6 +38,7 @@ add_executable(Template
 	src/Camera.cpp
 	src/Colormap.h
 	src/Colormap.cpp
+	src/PathFinder.cpp
 )
 
 target_compile_definitions(Template PRIVATE
@@ -71,24 +73,12 @@ file(GLOB_RECURSE UTIL_HEADERS
 )
 target_sources(Template PRIVATE ${UTIL_SOURCES} ${UTIL_HEADERS})
 
-if(DEV_MODE)
-	# In dev mode, we load resources from the source tree, so that when we
-	# dynamically edit resources (like shaders), these are correctly
-	# versionned.
-	target_compile_definitions(Template PRIVATE
-		RESOURCE_DIR="${CMAKE_CURRENT_SOURCE_DIR}/resources"
-	)
-else()
-	# In release mode, we just load resources relatively to wherever the
-	# executable is launched from, so that the binary is portable
-	target_compile_definitions(Template PRIVATE
-		RESOURCE_DIR="./resources"
-	)
-endif()
-
 target_include_directories(Template PRIVATE .)
 target_include_directories(Template PRIVATE src)
 target_include_directories(Template PRIVATE thirdparty)
+target_include_directories(Template PRIVATE ${CMAKE_BINARY_DIR})
+# message(STATUS  ${CMAKE_CURRENT_SOURCE_DIR})
+# message(STATUS  ${CMAKE_BINARY_DIR})
 
 target_link_libraries(Template PRIVATE glfw webgpu glfw3webgpu imgui)
 

--- a/resources/config.h.in
+++ b/resources/config.h.in
@@ -1,0 +1,4 @@
+#pragma once
+#include <string>
+std::string sourceDirectory = "@CMAKE_SOURCE_DIR@";
+std::string buildDirectory = "@CMAKE_BINARY_DIR@";

--- a/src/Colormap.cpp
+++ b/src/Colormap.cpp
@@ -3,10 +3,6 @@
 #include <iostream>
 #include <algorithm>
 
-#ifndef RESOURCE_DIR
-#define RESOURCE_DIR "this will be defined by cmake depending on the build type. This define is to disable error squiggles"
-#endif
-
 std::map<std::string, int> Colormap::indices;
 std::vector<std::string> Colormap::names;
 ResourceManager::Image Colormap::colormaps;
@@ -42,9 +38,10 @@ glm::vec3 Colormap::operator()(float value)
     return color(value);
 }
 
+#include "PathFinder.h"
 void Colormap::init()
 {
-    std::filesystem::path path = RESOURCE_DIR "/colormaps.txt";
+    std::filesystem::path path = resolveFile("resources/colormaps.txt");
     std::ifstream file(path);
     if (!file.is_open())
     {
@@ -62,6 +59,6 @@ void Colormap::init()
         indices[line] = offset;
         offset++;
     }
-    path = RESOURCE_DIR "/colormaps.png";
+    path = resolveFile("resources/colormaps.png");
     colormaps = ResourceManager::loadImage(path);
 }

--- a/src/PathFinder.cpp
+++ b/src/PathFinder.cpp
@@ -1,0 +1,97 @@
+#include <sstream>
+#include <iostream>
+#include <filesystem>
+#include "PathFinder.h"
+#include <config/config.h>
+
+std::filesystem::path expand(std::filesystem::path in) {
+	namespace fs = std::filesystem;
+#ifndef _WIN32
+	if (in.string().size() < 1) return in;
+
+	const char * home = getenv("HOME");
+	if (home == NULL) {
+		std::cerr << "error: HOME variable not set." << std::endl;
+		throw std::invalid_argument("error: HOME environment variable not set.");
+	}
+
+	std::string s = in.string();
+	if (s[0] == '~') {
+		s = std::string(home) + s.substr(1, s.size() - 1);
+		return fs::path(s);
+	}
+	else {
+		return in;
+	}
+#else
+	if (in.string().size() < 1) return in;
+
+	const char * home = getenv("USERPROFILE");
+	if (home == NULL) {
+		std::cerr << "error: USERPROFILE variable not set." << std::endl;
+		throw std::invalid_argument("error: USERPROFILE environment variable not set.");
+	}
+
+	std::string s = in.string();
+	if (s[0] == '~') {
+		s = std::string(home) + s.substr(1, s.size() - 1);
+		return fs::path(s);
+	}
+	else {
+		return in;
+	}
+#endif 
+
+}
+ 
+std::filesystem::path workingDirectory;
+std::filesystem::path binaryDirectory;
+
+std::filesystem::path resolveFile(std::string fileName, std::vector<std::string> search_paths) {
+	namespace fs = std::filesystem;
+    fs::path working_dir = workingDirectory;
+    fs::path binary_dir = binaryDirectory;
+    fs::path source_dir = sourceDirectory;
+    fs::path build_dir = buildDirectory;
+
+	fs::path expanded = expand(fs::path(fileName));
+
+	fs::path base_path = "";
+        if (fs::exists(expand(fs::path(fileName))))
+          return expand(fs::path(fileName));
+	for (const auto& path : search_paths){
+		auto p = expand(fs::path(path));
+		if (fs::exists(p / fileName))
+			return p.string() + std::string("/") + fileName;
+}
+
+	if (fs::exists(fileName)) return fs::path(fileName);
+        if (fs::exists(expanded))
+          return expanded;
+
+        for (const auto &pathi : search_paths) {
+                        auto path = expand(fs::path(pathi));
+          if (fs::exists(working_dir / path / fileName))
+            return (working_dir / path / fileName).string();
+          if (fs::exists(binary_dir / path / fileName))
+            return (binary_dir / path / fileName).string();
+          if (fs::exists(source_dir / path / fileName))
+            return (source_dir / path / fileName).string();
+          if (fs::exists(build_dir / path / fileName))
+            return (build_dir / path / fileName).string();
+        }
+
+	if (fs::exists(working_dir / fileName))
+          return (working_dir / fileName);
+        if (fs::exists(binary_dir / fileName))
+          return (binary_dir / fileName);
+        if (fs::exists(source_dir / fileName))
+          return (source_dir / fileName);
+        if (fs::exists(build_dir / fileName))
+          return (build_dir / fileName);
+
+	std::stringstream sstream;
+	sstream << "File '" << fileName << "' could not be found in any provided search path" << std::endl;
+	std::cerr << sstream.str();
+	throw std::runtime_error(sstream.str().c_str());
+}

--- a/src/PathFinder.h
+++ b/src/PathFinder.h
@@ -1,0 +1,9 @@
+#pragma once
+#include <sstream>
+#include <filesystem>
+
+std::filesystem::path expand(std::filesystem::path in);
+std::filesystem::path resolveFile(std::string fileName, std::vector<std::string> search_paths = {});
+
+extern std::filesystem::path workingDirectory;
+extern std::filesystem::path binaryDirectory;

--- a/src/Renderer.cpp
+++ b/src/Renderer.cpp
@@ -13,10 +13,6 @@
 
 using namespace wgpu;
 
-#ifndef RESOURCE_DIR
-#define RESOURCE_DIR "this will be defined by cmake depending on the build type. This define is to disable error squiggles"
-#endif
-
 Renderer::Renderer()
 {
 	initWindowAndDevice();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,8 +1,13 @@
 #include "Renderer.h"
 #include "Simulator.h"
+#include "PathFinder.h"
 
-int main(int, char **)
+int main(int argc, char ** argv)
 {
+	namespace fs = std::filesystem;
+	workingDirectory = fs::absolute(fs::path(argv[0])).remove_filename();
+    binaryDirectory = fs::current_path();
+
 	Renderer renderer = Renderer();
 	Simulator simulator(renderer);
 

--- a/src/pipelines/ImagePipeline.cpp
+++ b/src/pipelines/ImagePipeline.cpp
@@ -1,9 +1,6 @@
 #include "ImagePipeline.h"
 #include "Colormap.h"
-
-#ifndef RESOURCE_DIR
-#define RESOURCE_DIR "this will be defined by cmake depending on the build type. This define is to disable error squiggles"
-#endif
+#include "PathFinder.h"
 
 using namespace wgpu;
 
@@ -12,7 +9,7 @@ bool ImagePipeline::init(Device &device, TextureFormat &swapChainFormat, Queue &
     this->device = device;
     this->queue = queue;
     this->swapChainFormat = swapChainFormat;
-    shaderModule = ResourceManager::loadShaderModule(RESOURCE_DIR "/image_shader.wgsl", device);
+    shaderModule = ResourceManager::loadShaderModule(resolveFile("resources/image_shader.wgsl"), device);
     RenderPipelineDescriptor pipelineDesc;
     pipelineDesc.label = "Image pipeline";
 

--- a/src/pipelines/InstancingPipeline.cpp
+++ b/src/pipelines/InstancingPipeline.cpp
@@ -1,11 +1,8 @@
 #include "InstancingPipeline.h"
 #include "Renderer.h"
+#include "PathFinder.h"
 #include <numeric>
 #include <algorithm>
-
-#ifndef RESOURCE_DIR
-#define RESOURCE_DIR "this will be defined by cmake depending on the build type. This define is to disable error squiggles"
-#endif
 
 using namespace wgpu;
 using PrimitiveVertexAttributes = ResourceManager::PrimitiveVertexAttributes;
@@ -17,7 +14,7 @@ void InstancingPipeline::init(Device &device, Queue &queue, TextureFormat &swapC
     this->lightingUniforms = lightingUniforms;
     this->device = device;
     this->queue = queue;
-    shaderModule = ResourceManager::loadShaderModule(RESOURCE_DIR "/instancing_shader.wgsl", device);
+    shaderModule = ResourceManager::loadShaderModule(resolveFile("resources/instancing_shader.wgsl"), device);
     RenderPipelineDescriptor pipelineDesc;
 
     std::vector<VertexAttribute> lineVertexAttribs(2);

--- a/src/pipelines/LinePipeline.cpp
+++ b/src/pipelines/LinePipeline.cpp
@@ -1,9 +1,6 @@
 #include "LinePipeline.h"
 #include "Renderer.h"
-
-#ifndef RESOURCE_DIR
-#define RESOURCE_DIR "this will be defined by cmake depending on the build type. This define is to disable error squiggles"
-#endif
+#include "PathFinder.h"
 
 using namespace wgpu;
 using LineVertexAttributes = ResourceManager::LineVertexAttributes;
@@ -14,7 +11,7 @@ void LinePipeline::init(Device &device, Queue &queue, TextureFormat &swapChainFo
     this->lightingUniforms = lightingUniforms;
     this->device = device;
     this->queue = queue;
-    shaderModule = ResourceManager::loadShaderModule(RESOURCE_DIR "/line_shader.wgsl", device);
+    shaderModule = ResourceManager::loadShaderModule(resolveFile("resources/line_shader.wgsl"), device);
     RenderPipelineDescriptor pipelineDesc;
 
     // This is for instanced rendering

--- a/src/pipelines/PostProcessingPipeline.cpp
+++ b/src/pipelines/PostProcessingPipeline.cpp
@@ -1,16 +1,13 @@
 #include "PostProcessingPipeline.h"
 #include "ResourceManager.h"
-
-#ifndef RESOURCE_DIR
-#define RESOURCE_DIR "this will be defined by cmake depending on the build type. This define is to disable error squiggles"
-#endif
+#include "PathFinder.h"
 
 using namespace wgpu;
 
 bool PostProcessingPipeline::init(Device &device, TextureFormat &swapChainFormat, TextureView &textureView)
 {
     this->device = device;
-    shaderModule = ResourceManager::loadShaderModule(RESOURCE_DIR "/post_processing.wgsl", device);
+    shaderModule = ResourceManager::loadShaderModule(resolveFile("resources/post_processing.wgsl"), device);
     RenderPipelineDescriptor pipelineDesc;
     pipelineDesc.label = "Post process pipeline";
 


### PR DESCRIPTION
There was an issue in the collision detection code that seems to have been around for quite some time, i.e., even the previous template had the same bug (see the old collisionDetect.h function lines 225-241 that has been unchanged for seven years) as part of the SAT. 

The bug manifests in collision points for vertices to faces being computed wrongly (edge-edge works) where the returned result appears to always be the closest vertex to the origin, which is true in some cases but in most it is not. This stems from the 'handleVertexToface' function that is given the vertices of one OBB (described via its transformation matrix) and the difference between the centers of masses of the objects. How this code is supposed to work, I am unsure.

A more correct implementation would be to take the collision normal (which we have access to anyways) and use this normal to project the distance between the _vertices_ (not center of mass) of the colliding object with respect to the center of mass of the collided object and pick the vertex for which this projection is smallest. To implement this we need to change the signature of the function to now take the center of mass as argument, as well as the normal. Implementing the code then is straight forward.

Credit for finding this problem goves to a student https://github.com/TobiasEppacher

This student also developed a simple test case to debug this issue (not shared here as it would require sharing their exercise submission to debug with).