### PR TITLE
[REFA] CollisionDetection: Made parameters const, removed helper from header

### DIFF
--- a/src/util/CollisionDetection.cpp
+++ b/src/util/CollisionDetection.cpp
@@ -368,11 +368,10 @@ namespace collisionTools
         return info;
     }
 
-    CollisionInfo checkCollisionSAT(glm::mat4 &worldFromObj_A, glm::mat4 &worldFromObj_B)
+    CollisionInfo checkCollisionSAT(const glm::mat4 &worldFromObj_A, const glm::mat4 &worldFromObj_B)
     {
-        using namespace collisionTools;
-        vec3 calSizeA = getBoxSize(worldFromObj_A);
-        vec3 calSizeB = getBoxSize(worldFromObj_B);
+        const vec3 calSizeA = getBoxSize(worldFromObj_A);
+        const vec3 calSizeB = getBoxSize(worldFromObj_B);
 
         return checkCollisionSATHelper(worldFromObj_A, worldFromObj_B, calSizeA, calSizeB);
     }

--- a/src/util/CollisionDetection.h
+++ b/src/util/CollisionDetection.h
@@ -55,7 +55,7 @@ namespace collisionTools
     obj2World_A, the transfer matrix from object space of A to the world space
     obj2World_B, the transfer matrix from object space of B to the world space
     */
-    CollisionInfo checkCollisionSAT(glm::mat4 &worldFromObj_A, glm::mat4 &worldFromObj_B);
+    CollisionInfo checkCollisionSAT(const glm::mat4 &worldFromObj_A, const glm::mat4 &worldFromObj_B);
 
     // example of using the checkCollisionSAT function
     void testCheckCollision(int caseid);

--- a/src/util/CollisionDetection.h
+++ b/src/util/CollisionDetection.h
@@ -49,8 +49,6 @@ namespace collisionTools
 
     glm::vec3 handleVertexToface(const glm::mat4 &worldFromObj, const glm::vec3 &toCenter);
 
-    CollisionInfo checkCollisionSATHelper(const glm::mat4 &worldFromObj_A, const glm::mat4 &worldFromObj_B, glm::vec3 size_A, glm::vec3 size_B);
-
     /* params:
     obj2World_A, the transfer matrix from object space of A to the world space
     obj2World_B, the transfer matrix from object space of B to the world space


### PR DESCRIPTION
`checkCollisionSAT`: Made parameters const so the function can be used like this:
`const auto collisionInfo = collisionTools::checkCollisionSAT(rbA.localToWorldMatrix(), rbB.localToWorldMatrix());`
instead of having to create temporary variables and pass those to the function. 
Also made local variables const and removed an unnecessary `using namespace`.

Removed `checkCollisionSATHelper` from CollisionDetection.h to avoid confusion on which function to use.